### PR TITLE
Encourage inlining of Iter()

### DIFF
--- a/funcs_test.go
+++ b/funcs_test.go
@@ -79,3 +79,18 @@ func TestEqual(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkStringFunc(b *testing.B) {
+	m := New(bytes.Equal, maphash.Bytes,
+		KeyElem[[]byte, struct{}]{[]byte("abc"), struct{}{}},
+		KeyElem[[]byte, struct{}]{[]byte("def"), struct{}{}},
+		KeyElem[[]byte, struct{}]{[]byte("ghi"), struct{}{}},
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		StringFunc(m,
+			func(b []byte) string { return string(b) },
+			func(struct{}) string { return "x" })
+	}
+}

--- a/map_test.go
+++ b/map_test.go
@@ -395,3 +395,19 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkIter(b *testing.B) {
+	m := New[string, int](
+		func(a, b string) bool { return a == b },
+		maphash.String,
+		KeyElem[string, int]{"one", 1},
+		KeyElem[string, int]{"two", 2},
+		KeyElem[string, int]{"three", 3},
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for it := m.Iter(); it.Next(); {
+		}
+	}
+}


### PR DESCRIPTION
Simplifying Iter() by moving its implementation to another function call encouarages Iter() to be inlined into its caller. With Iter inlined its possible for the compiler to see that the `it` object doesn't escape and can be stored on the stack.

Inspiration comes frrom:
https://words.filippo.io/efficient-go-apis-with-the-inliner/

BenchmarkStringFunc shows the effect of this with one fewer allocation. The inlining doesn't happen for BenchmarkIter for some reason, but the rewritten code is still faster somehow.

name           old time/op    new time/op    delta
StringFunc-16     464ns ± 0%     389ns ± 0%  -16.06%  (p=0.000 n=7+10)
Iter-16           132ns ± 1%     121ns ± 1%   -7.83%  (p=0.000 n=9+10)

name           old alloc/op   new alloc/op   delta
StringFunc-16      233B ± 0%      137B ± 0%  -41.20%  (p=0.000 n=10+10)
Iter-16           96.0B ± 0%     96.0B ± 0%     ~     (all equal)

name           old allocs/op  new allocs/op  delta
StringFunc-16      6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
Iter-16            1.00 ± 0%      1.00 ± 0%     ~     (all equal)